### PR TITLE
fix: 카테고리별 항목 개수 표시

### DIFF
--- a/app/president/pledges/page.tsx
+++ b/app/president/pledges/page.tsx
@@ -121,7 +121,9 @@ export default function PresidentialPledgesPage() {
           >
             <span>{category.name}</span>
             <Badge variant="secondary" className="ml-1">
-              {0}
+              {category.id === "all"
+                ? pledges.length
+                : pledges.filter((p) => p.category === category.id).length}
             </Badge>
           </Button>
         ))}


### PR DESCRIPTION
안녕하세요, 대통령실 홈페이지 작업하신 것 구경하다가 코드 기여하고 싶어서 PR올립니다. 
확인해보시고 제가 작업한 코드가 도움이 되신다면 반영 부탁드립니다 😸 
감사합니다.


## ✨ 작업 내용
- 기존에는 카테고리 목록에 항목 개수가 표시되지 않았습니다.
- 각 카테고리별로 포함된 항목 수를 계산하여, 이름 옆에 표시되도록 수정했습니다.
  전체일 경우에만 pledges 데이터 개수만큼 보여주고 그 외에는 카테고리에 맞게 보이도록 필터링 했습니다.

## ✨ 작업 전후 화면 캡쳐
As-Is
<img width="800" alt="화면 캡처 2025-06-18 170523" src="https://github.com/user-attachments/assets/fd4d224a-53b5-45e3-89be-3c06dc3221fb" />

To-be
<img width="800" alt="화면 캡처 2025-06-18 170437" src="https://github.com/user-attachments/assets/82fe32e4-6cd8-46f4-9119-f06b603f491b" />

## 🔍 작업 이유
- 사용자 입장에서 어떤 카테고리에 콘텐츠가 많은지 미리 알 수 있도록 개선했습니다.
- UI 가독성과 탐색 효율성이 향상됩니다.

## ✅ 테스트 방법
1. 정책대표 공약 페이지로 이동합니다.
2. 각 카테고리 이름 옆에 항목 개수가 괄호로 표시되는지 확인합니다.  
   예: `전체(6)`, ` 외교(1)` 등
3. 카테고리 항목을 클릭했을 때에도 개수가 올바르게 표시되는 지 확인합니다.
